### PR TITLE
Add a missing call for `fallbackHandler`

### DIFF
--- a/routing/fallback-handlers/main.go
+++ b/routing/fallback-handlers/main.go
@@ -7,6 +7,9 @@ import (
 func main() {
 	app := iris.New()
 
+	// add a fallback handler to process requests that would not be declared in the router.
+	app.Fallback(fallbackHandler)
+
 	// this works as expected now,
 	// will handle *all* expect DELETE requests, even if there is no routes
 	app.Get("/action/{p}", h)


### PR DESCRIPTION
This is continuation of PR #28 .
Something had been forgotten.