### PR TITLE
Removed Configurator to make the app runnable

### DIFF
--- a/mvc/login/main.go
+++ b/mvc/login/main.go
@@ -79,8 +79,6 @@ func main() {
 	app.Run(
 		// Starts the web server at localhost:8080
 		iris.Addr("localhost:8080"),
-		// Disables the updater.
-		iris.WithoutVersionChecker,
 		// Ignores err server closed log when CTRL/CMD+C pressed.
 		iris.WithoutServerError(iris.ErrServerClosed),
 		// Enables faster json serialization and more.


### PR DESCRIPTION
Hi this example is outdated. It still uses `iris.WithoutVersionChecher` Configurator.

I'm not sure what is the replacement for that Configurator.

Thanks!